### PR TITLE
Dockerize product microservice

### DIFF
--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -1,0 +1,46 @@
+#### Start of builder image
+# ------------------------
+# Builder stage to prepare application for final image
+FROM openjdk:14-slim-buster as builder
+WORKDIR temp
+
+# Could be set to different jar file location
+ARG JAR_FILE=target/*.jar
+
+# Copy fat jar file to current image builder
+COPY ${JAR_FILE} application.jar
+
+# Extract the jar file layers
+RUN java -Djarmode=layertools -jar --enable-preview application.jar extract
+#### End of builder stage
+
+#### Start of actual image
+# ------------------------
+# Build image based on JDK 14 base image, based on latest debian buster OS
+FROM openjdk:14-slim-buster
+MAINTAINER Mohamed Taman <mohamed.taman@gmail.com>
+
+# Set image information
+LABEL version="0.1.beta" name="Product Service"
+
+# Limiting security access to not user root user
+RUN addgroup siriusxi && useradd -g siriusxi -ms /bin/bash taman
+
+# Setting user to current created user
+USER taman
+
+# Set working directory to application folder
+WORKDIR /home/taman/application
+
+# Copy all layers from builder stage to current image
+COPY --from=builder temp/dependencies/ ./
+COPY --from=builder temp/snapshot-dependencies/ ./
+COPY --from=builder temp/resources/ ./
+COPY --from=builder temp/application/ ./
+
+# Expose current application to port 8080
+EXPOSE 8080
+
+# Run the application
+ENTRYPOINT ["bash", "-c", \
+"java --enable-preview ${JAVA_OPTS} org.springframework.boot.loader.JarLauncher ${0} ${@}"]

--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -19,3 +19,12 @@ management:
   endpoint:
     shutdown:
       enabled: true
+
+# This is a docker specific profile properties
+# Also profiles could be separated in its owen file
+# with file name format of "application-docker.yaml"
+---
+spring:
+  profiles: docker
+server:
+  port: 8080

--- a/store-chassis/pom.xml
+++ b/store-chassis/pom.xml
@@ -16,7 +16,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Springy Store Chassis</name>
-    <description>Parent pom project for Spring Boot μServices</description>
+    <description>Parent pom project for Springy μServices</description>
 
     <modules>
         <module>../product-composite-service</module>
@@ -80,7 +80,7 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <!-- Application business dependencies to be inherited by all sub-modules -->
         <dependency>
             <groupId>com.siriusxi.ms.store</groupId>
             <artifactId>store-api</artifactId>
@@ -99,6 +99,10 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Make final jar, a layered jar -->
+                    <layout>LAYERED_JAR</layout>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
- Create a specific docker file, that also separates the libs from the main Jar for docker layer caching and reusability.
- Image is based on Java jdk openjdk:14-slim-buster.
- Use a multi-stage docker file to unzip the files for better image layering and faster startup