### PR TITLE
Simplify maven build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,20 @@ And you should expect output like this:
 Installing all Springy store core shared modules
 ................................................
 
-1- Installing shared [Utilities] module...
+1- Installing [build parent] module...
 Done successfully.
 
-2- Installing shared [APIs] module...
+2- Installing shared [Utilities] module...
 Done successfully.
 
-3- Installing [parent project] module...
+3- Installing shared [APIs] module...
 Done successfully.
 
-Wooohooo, building & installing all project modules are finished successfully.
-and the project is ready for the next step. :)
+4- Installing [service parent] module...
+Done successfully.
+
+Woohoo, building & installing all project modules are finished successfully.
+The project is ready for the next step. :)
 ```
 
 #### Second: Build & Test Microservices
@@ -117,7 +120,7 @@ Now it is time to build our **4 microservices** and run each service integration
 
 ```bash
 mohamed.taman@DTLNV8 ~/springy-store-microservices 
-λ ./mvnw clean verify -f store-chassis/
+λ ./mvnw clean verify
 ```
 
 All build commands and test suite for each microservice should run successfully, and the final output should be like this:

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,12 @@
     <description>Aggregator pom project for Springy μServices</description>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+
     <modules>
         <module>product-composite-service</module>
         <module>product-service</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.siriusxi.ms.store</groupId>
+    <artifactId>store-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Springy Store Aggregator</name>
+    <description>Aggregator pom project for Springy μServices</description>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>product-composite-service</module>
+        <module>product-service</module>
+        <module>review-service</module>
+        <module>recommendation-service</module>
+        <module>store-api</module>
+        <module>store-utils</module>
+        <module>store-build-chassis</module>
+        <module>store-service-chassis</module>
+    </modules>
+</project>

--- a/product-composite-service/pom.xml
+++ b/product-composite-service/pom.xml
@@ -4,11 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
 		<groupId>com.siriusxi.ms.store</groupId>
-		<artifactId>store-chassis</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../store-chassis</relativePath>
+		<artifactId>store-service-chassis</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../store-service-chassis</relativePath>
 	</parent>
 	
 	<artifactId>product-composite-service</artifactId>

--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -4,11 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
 		<groupId>com.siriusxi.ms.store</groupId>
-		<artifactId>store-chassis</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../store-chassis</relativePath>
+		<artifactId>store-service-chassis</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../store-service-chassis</relativePath>
 	</parent>
 	
 	<artifactId>product-service</artifactId>

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -4,11 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
 		<groupId>com.siriusxi.ms.store</groupId>
-		<artifactId>store-chassis</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../store-chassis</relativePath>
+		<artifactId>store-service-chassis</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../store-service-chassis</relativePath>
 	</parent>
 	
 	<artifactId>recommendation-service</artifactId>

--- a/review-service/pom.xml
+++ b/review-service/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
 		<groupId>com.siriusxi.ms.store</groupId>
-		<artifactId>store-chassis</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../store-chassis</relativePath>
+		<artifactId>store-service-chassis</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../store-service-chassis</relativePath>
 	</parent>
 
 	<artifactId>review-service</artifactId>

--- a/run-em-all.sh
+++ b/run-em-all.sh
@@ -6,7 +6,7 @@ echo -e "Starting [Springy Store] μServices ....\n\
 ---------------------------------------\n"
 
 function runService(){
-   ./mvnw --quiet spring-boot:run -Dspring-boot.run.jvmArguments="--enable-preview" -f $1
+   ./mvnw --quiet spring-boot:run -Dspring-boot.run.jvmArguments="--enable-preview" -pl $1
 }
 
 for dir in `find *-service -maxdepth 0 -type d`

--- a/setup.sh
+++ b/setup.sh
@@ -3,14 +3,18 @@
 ## version: v1.0
 echo -e "\nInstalling all Springy store core shared modules"
 echo -e  "................................................\n"
-echo "1- Installing shared [Utilities] module..."
-./mvnw --quiet clean install -f store-utils || exit 126
+echo "1- Installing [build parent] module..."
+./mvnw --quiet clean install -pl store-build-chassis || exit 126
 echo -e "Done successfully.\n"
-echo "2- Installing shared [APIs] module..."
-./mvnw --quiet clean install -f store-api || exit 126
+echo "2- Installing shared [Utilities] module..."
+./mvnw --quiet clean install -pl store-utils || exit 126
 echo -e "Done successfully.\n"
-echo "3- Installing [Parent] module..."
-./mvnw --quiet clean install -N -f store-chassis || exit 126
+echo "3- Installing shared [APIs] module..."
+./mvnw --quiet clean install -pl store-api || exit 126
 echo -e "Done successfully.\n"
+echo "4- Installing [service parent] module..."
+./mvnw --quiet clean install -pl store-service-chassis || exit 126
+echo -e "Done successfully.\n"
+
 echo -e "Woohoo, building & installing all project modules are finished successfully.\n\
 The project is ready for the next step. :)"

--- a/store-api/pom.xml
+++ b/store-api/pom.xml
@@ -4,7 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.siriusxi.ms.store</groupId>
+    <parent>
+        <groupId>com.siriusxi.ms.store</groupId>
+        <artifactId>store-build-chassis</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../store-build-chassis</relativePath>
+    </parent>
+
     <artifactId>store-api</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>Springy Store APIs</name>
@@ -12,64 +18,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <java.version>14</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Libraries versions -->
         <spring.boot.dependencies.version>2.3.0.M4</spring.boot.dependencies.version>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
-        <maven.failsafe.plugin.version>3.0.0-M4</maven.failsafe.plugin.version>
-        <maven.install.skip>false</maven.install.skip>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
-
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.plugin.version}</version>
-                <configuration>
-                    <release>${java.version}</release>
-                    <compilerArgs>
-                        --enable-preview
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>
-                        --enable-preview
-                    </argLine>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.failsafe.plugin.version}</version>
-                <configuration>
-                    <argLine>
-                        --enable-preview
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -82,19 +33,15 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </pluginRepository>
-    </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/store-build-chassis/pom.xml
+++ b/store-build-chassis/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.3.0.M4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.siriusxi.ms.store</groupId>
+    <artifactId>store-build-chassis</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Springy Store Build Chassis</name>
+    <description>Parent pom project for Building Springy μServices</description>
+    <packaging>pom</packaging>
+
+    <properties>
+        <java.version>14</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.config.file.location>../config/maven/store.properties</project.config.file.location>
+
+        <!--  Dependencies versions properties  -->
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+        <maven.failsafe.plugin.version>3.0.0-M4</maven.failsafe.plugin.version>
+        <maven.plugin.properties.version>1.0.0</maven.plugin.properties.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.plugin.version}</version>
+                    <configuration>
+                        <release>${java.version}</release>
+                        <compilerArgs>--enable-preview</compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire.plugin.version}</version>
+                    <configuration>
+                        <argLine>--enable-preview</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven.failsafe.plugin.version}</version>
+                    <configuration>
+                        <argLine>--enable-preview</argLine>
+                    </configuration>
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/store-service-chassis/pom.xml
+++ b/store-service-chassis/pom.xml
@@ -4,39 +4,21 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.0.M4</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>com.siriusxi.ms.store</groupId>
+        <artifactId>store-build-chassis</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../store-build-chassis</relativePath>
     </parent>
 
-    <groupId>com.siriusxi.ms.store</groupId>
-    <artifactId>store-chassis</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <artifactId>store-service-chassis</artifactId>
+    <version>1.0-SNAPSHOT</version>
     <name>Springy Store Chassis</name>
     <description>Parent pom project for Springy μServices</description>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>../product-composite-service</module>
-        <module>../product-service</module>
-        <module>../review-service</module>
-        <module>../recommendation-service</module>
-        <module>../store-api</module>
-        <module>../store-utils</module>
-    </modules>
-
     <properties>
-        <java.version>14</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.config.file.location>../config/maven/store.properties
-        </project.config.file.location>
-
         <!--  Dependencies versions properties  -->
         <maven.plugin.dockerfile.version>1.4.13</maven.plugin.dockerfile.version>
-        <maven.plugin.properties.version>1.0.0</maven.plugin.properties.version>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>
@@ -165,31 +147,6 @@
                     </layers>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>${java.version}</release>
-                    <compilerArgs>
-                        --enable-preview
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
     <!-- Project profiles definition -->
@@ -243,20 +200,4 @@
             </build>
         </profile>
     </profiles>
-
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/store-utils/pom.xml
+++ b/store-utils/pom.xml
@@ -4,25 +4,35 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.siriusxi.ms.store</groupId>
     <artifactId>store-utils</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>Springy Store Utils</name>
     <description>Project that define all Springy Store shared functionality</description>
     <packaging>jar</packaging>
 
+    <parent>
+        <groupId>com.siriusxi.ms.store</groupId>
+        <artifactId>store-build-chassis</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../store-build-chassis</relativePath>
+    </parent>
+
     <properties>
-        <java.version>14</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Libraries versions -->
         <spring.boot.dependencies.version>2.3.0.M4</spring.boot.dependencies.version>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
-        <maven.failsafe.plugin.version>3.0.0-M4</maven.failsafe.plugin.version>
-        <maven.install.skip>false</maven.install.skip>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.dependencies.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -40,71 +50,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.plugin.version}</version>
-                <configuration>
-                    <release>${java.version}</release>
-                    <compilerArgs>
-                        --enable-preview
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.failsafe.plugin.version}</version>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
-            </plugin>
-
-        </plugins>
-    </build>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.dependencies.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>


### PR DESCRIPTION
I noticed that the store-chassis module was serving multiple purposes:

1. Aggregating the service modules in one build
2. Defining common build information (duplicated in the api and utils module)
3. Defining service build and dependency information

I tried to split these purposes and removing the duplication in the stand alone modules by:
- creating an aggregator pom that builds everything
- creating a store-build-chassis that defines common build information (which is also used by the api and utils module
- creating a store-service-chasses that defines service build and dependency information.

Looking forward to hear your thoughts.