### PR TITLE
Set mongodb auto-index-creation true

### DIFF
--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -6,6 +6,10 @@ spring:
       host: localhost
       port: 27017
       database: product-db
+      auto-index-creation: true
+
+
+
 
 server:
   port: 9081

--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -7,10 +7,7 @@ spring:
       port: 27017
       database: product-db
       auto-index-creation: true
-
-
-
-
+      
 server:
   port: 9081
 

--- a/product-service/src/test/java/com/siriusxi/ms/store/ps/PersistenceTests.java
+++ b/product-service/src/test/java/com/siriusxi/ms/store/ps/PersistenceTests.java
@@ -4,7 +4,6 @@ import com.siriusxi.ms.store.ps.persistence.ProductEntity;
 import com.siriusxi.ms.store.ps.persistence.ProductRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -76,9 +75,7 @@ public class PersistenceTests {
     assertEqualsProduct(savedEntity, entity.get());
   }
 
-  //FIXME error which is not thrown
   @Test
-  @Disabled
   public void duplicateError() {
 
     Assertions.assertThrows(

--- a/recommendation-service/src/main/resources/application.yaml
+++ b/recommendation-service/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ spring:
       host: localhost
       port: 27017
       database: recommendation-db
+      auto-index-creation: true
 
 server:
   port: 9082

--- a/recommendation-service/src/test/java/com/siriusxi/ms/store/rs/PersistenceTests.java
+++ b/recommendation-service/src/test/java/com/siriusxi/ms/store/rs/PersistenceTests.java
@@ -1,14 +1,14 @@
 package com.siriusxi.ms.store.rs;
 
-import com.mongodb.DuplicateKeyException;
+
 import com.siriusxi.ms.store.rs.persistence.RecommendationEntity;
 import com.siriusxi.ms.store.rs.persistence.RecommendationRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 
 import java.util.List;
@@ -73,9 +73,8 @@ public class PersistenceTests {
         assertEqualsRecommendation(savedEntity, entityList.get(0));
     }
 
-    //FIXME error which is not thrown
+
     @Test
-    @Disabled
     public void duplicateError() {
 
         Assertions.assertThrows(DuplicateKeyException.class,


### PR DESCRIPTION
The integrity validation was not happening due to  Automatic index creation is disabled by default as of Spring Data MongoDB 3.x. so there no validation is happening on the indexed columns.

By default MongoMappingContext#setAutoIndexCreation(boolean)' or override 'MongoConfigurationSupport#autoIndexCreation()' to be explicit set .

for more details [spring boot](https://github.com/spring-projects/spring-boot/commit/bf6f9b4c43355b92a3c5de4bec1af0e4deaf3ec5)
 